### PR TITLE
Comment out Redis dependency since the cache is not implemented yet

### DIFF
--- a/basic_yahoo_finance.gemspec
+++ b/basic_yahoo_finance.gemspec
@@ -24,6 +24,6 @@ Gem::Specification.new do |spec|
   spec.metadata["rubygems_mfa_required"] = "true"
   spec.metadata["source_code_uri"] = "https://github.com/towards/basic_yahoo_finance"
 
-  spec.add_dependency "redis", "~> 4.2"
+  # spec.add_dependency "redis", "~> 5.0"
   spec.add_development_dependency "minitest-emoji", "~> 2.0"
 end

--- a/lib/basic_yahoo_finance.rb
+++ b/lib/basic_yahoo_finance.rb
@@ -2,7 +2,7 @@
 
 require "json"
 require "open-uri"
-require_relative "basic_yahoo_finance/cache"
+# require_relative "basic_yahoo_finance/cache"
 require_relative "basic_yahoo_finance/util"
 require_relative "basic_yahoo_finance/version"
 


### PR DESCRIPTION
Just a small commit commenting out the Redis dependency. The cache is not implemented yet, however, the outdated dependency causes bundles to nail Redis to version 4. Thanks for considering a patchlevel release to make this gem behave nicely again. 🎉 