### PR TITLE
Feat/implement persistent http

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem "rake", "~> 13.0"
 
 gem "rubocop", "~> 1.50"
 
-gem 'net-http-persistent', '~> 4.0', '>= 4.0.2'
+gem "net-http-persistent", "~> 4.0", ">= 4.0.2"
 
 gem "simplecov", require: false, group: :test
 gem "simplecov-formatter-badge", require: false, group: :test

--- a/Gemfile
+++ b/Gemfile
@@ -9,5 +9,7 @@ gem "rake", "~> 13.0"
 
 gem "rubocop", "~> 1.50"
 
+gem 'net-http-persistent', '~> 4.0', '>= 4.0.2'
+
 gem "simplecov", require: false, group: :test
 gem "simplecov-formatter-badge", require: false, group: :test

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,9 +7,12 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
+    connection_pool (2.4.1)
     docile (1.4.0)
     json (2.6.3)
     minitest-emoji (2.0.0)
+    net-http-persistent (4.0.2)
+      connection_pool (~> 2.2)
     parallel (1.23.0)
     parser (3.2.2.1)
       ast (~> 2.4.1)
@@ -46,6 +49,7 @@ PLATFORMS
 DEPENDENCIES
   basic_yahoo_finance!
   minitest-emoji (~> 2.0)
+  net-http-persistent (~> 4.0, >= 4.0.2)
   rake (~> 13.0)
   rubocop (~> 1.50)
   simplecov

--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ Instantiate the `Query` class and use the quotes method on it with a single stoc
 
 query = BasicYahooFinance::Query.new
 data = query.quotes('AVEM', 'price')
-# The module argument can be left empty as the price module is the default
+
+# OR the module argument can be left empty as the price module is the default
 data = query.quotes('AVEM')
 
 # Query multiple stocks

--- a/coverage/coverage.svg
+++ b/coverage/coverage.svg
@@ -14,6 +14,6 @@
 <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="110">
   <text x="305" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="490">coverage</text>
   <text x="305" y="140" transform="scale(.1)" textLength="490">coverage</text>
-  <text x="755" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="250">97%</text>
-  <text x="755" y="140" transform="scale(.1)" textLength="250">97%</text></g>
+  <text x="755" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="250">96%</text>
+  <text x="755" y="140" transform="scale(.1)" textLength="250">96%</text></g>
 </svg>

--- a/lib/basic_yahoo_finance.rb
+++ b/lib/basic_yahoo_finance.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "json"
-# require "open-uri"
 require "net/http/persistent"
 require "net/http"
 
@@ -24,7 +23,7 @@ module BasicYahooFinance
       http = Net::HTTP::Persistent.new
       http.override_headers["User-Agent"] = "BYF/#{BasicYahooFinance::VERSION}"
       symbols.each do |sym|
-        uri = URI "#{API_URL}/v10/finance/quoteSummary/#{sym}?modules=#{mod}"
+        uri = URI("#{API_URL}/v10/finance/quoteSummary/#{sym}?modules=#{mod}")
         response = http.request(uri)
         hash_result.store(sym, process_output(JSON.parse(response.body), mod))
       rescue Net::HTTPBadResponse, Net::HTTPNotFound, Net::HTTPServerError, JSON::ParserError

--- a/lib/basic_yahoo_finance.rb
+++ b/lib/basic_yahoo_finance.rb
@@ -26,8 +26,8 @@ module BasicYahooFinance
         uri = URI("#{API_URL}/v10/finance/quoteSummary/#{sym}?modules=#{mod}")
         response = http.request(uri)
         hash_result.store(sym, process_output(JSON.parse(response.body), mod))
-      rescue Net::HTTPBadResponse, Net::HTTPNotFound, Net::HTTPServerError, JSON::ParserError
-        hash_result.store("Error", "HTTP Error")
+      rescue Net::HTTPBadResponse, Net::HTTPNotFound, Net::HTTPError, Net::HTTPServerError, JSON::ParserError
+        hash_result.store(sym, "HTTP Error")
       end
 
       http.shutdown

--- a/test/test_basic_yahoo_finance.rb
+++ b/test/test_basic_yahoo_finance.rb
@@ -30,7 +30,8 @@ class BasicYahooFinanceTest < Minitest::Test
 
   def test_http_error
     error_message = @query.quotes("ZZZZ", "price")
-    assert_includes(error_message["ZZZZ"], "code")
+    expected_error = { "code" => "Not Found", "description" => "Quote not found for ticker symbol: ZZZZ" }
+    assert_equal(expected_error, error_message["ZZZZ"])
   end
 
   def test_find_fx_symbol_gbp_chf


### PR DESCRIPTION
Implement persistent http connections for looping through multiple stock requests.

Ran a test of 100 tickers in a quote, 21 seconds before using `open-uri`, 13 seconds after using `net-http-persistent` due to keeping the http connection open until all requests are complete. 