### PR TITLE
Added "history" method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Historical data query method (`history`) with support for single/multiple stocks and custom intervals
+
 ### Changed
 
 - Update gem dependencies and Ruby version

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Or install it yourself as:
 
 Instantiate the `Query` class and use the quotes method on it with either a single stock as a `String` and a single module as a `String` or by passing an `Array` of stocks such as show in the two examples below.
 
+### Quotes
+
 ```ruby
 # Query a stock, with the price module
 
@@ -51,6 +53,23 @@ data['AVEM']['regularMarketPrice']['fmt']
 # OR the raw value
 data["AVEM"]["regularMarketPrice"]["raw"]
 # 52.72
+```
+
+### Historical Data
+
+Use the `history` method to retrieve historical price data for one or more stocks. It requires a symbol, a start date (`period1`) and an end date (`period2`) as Unix timestamps. An optional `interval` parameter defaults to `"1d"`.
+
+```ruby
+query = BasicYahooFinance::Query.new
+
+# Daily history for a single stock
+data = query.history('AAPL', 1_700_000_000, 1_710_000_000)
+
+# Weekly history
+data = query.history('AAPL', 1_700_000_000, 1_710_000_000, '1wk')
+
+# Multiple stocks
+data = query.history(['AAPL', 'GOOG'], 1_700_000_000, 1_710_000_000)
 ```
 
 ## Development

--- a/lib/basic_yahoo_finance.rb
+++ b/lib/basic_yahoo_finance.rb
@@ -23,47 +23,47 @@ module BasicYahooFinance
       @crumb = fetch_crumb(@cookie)
     end
 
-    def quotes(symbol) # rubocop:disable Metrics/MethodLength
+    def quotes(symbol)
       hash_result = {}
-      symbols = make_symbols_array(symbol)
-      http = Net::HTTP::Persistent.new
-      http.override_headers["User-Agent"] = USER_AGENT
-      http.override_headers["Cookie"] = @cookie
-      symbols.each do |sym|
-        uri = URI("#{API_URL}/v7/finance/quote?symbols=#{sym}&crumb=#{@crumb}")
-        response = http.request(uri)
-        hash_result.store(sym, process_output(JSON.parse(response.body)))
-      rescue Net::HTTPBadResponse, Net::HTTPNotFound, Net::HTTPError, Net::HTTPServerError, JSON::ParserError
-        hash_result.store(sym, "HTTP Error")
-      end
 
-      http.shutdown
+      with_http do |http|
+        make_symbols_array(symbol).each do |sym|
+          uri = URI("#{API_URL}/v7/finance/quote?symbols=#{sym}&crumb=#{@crumb}")
+          response = http.request(uri)
+          hash_result.store(sym, process_output(JSON.parse(response.body)))
+        rescue Net::HTTPBadResponse, Net::HTTPNotFound, Net::HTTPError, Net::HTTPServerError, JSON::ParserError
+          hash_result.store(sym, "HTTP Error")
+        end
+      end
 
       hash_result
     end
 
     def history(symbol, period1, period2, interval = "1d")
       hash_result = {}
-      symbols = make_symbols_array(symbol)
 
-      http = Net::HTTP::Persistent.new
-      http.override_headers["User-Agent"] = USER_AGENT
-      http.override_headers["Cookie"] = @cookie
-
-      symbols.each do |sym|
-        uri = URI("#{API_URL}/v8/finance/chart/#{sym}?period1=#{period1}&period2=#{period2}&interval=#{interval}&crumb=#{@crumb}")
-        response = http.request(uri)
-        hash_result.store(sym, process_history_output(JSON.parse(response.body)))
-      rescue Net::HTTPBadResponse, Net::HTTPNotFound, Net::HTTPError, Net::HTTPServerError, JSON::ParserError
-        hash_result.store(sym, "HTTP Error")
+      with_http do |http|
+        make_symbols_array(symbol).each do |sym|
+          uri = URI("#{API_URL}/v8/finance/chart/#{sym}?period1=#{period1}&period2=#{period2}&interval=#{interval}&crumb=#{@crumb}")
+          response = http.request(uri)
+          hash_result.store(sym, process_history_output(JSON.parse(response.body)))
+        rescue Net::HTTPBadResponse, Net::HTTPNotFound, Net::HTTPError, Net::HTTPServerError, JSON::ParserError
+          hash_result.store(sym, "HTTP Error")
+        end
       end
-
-      http.shutdown
 
       hash_result
     end
 
     private
+
+    def with_http
+      http = Net::HTTP::Persistent.new
+      http.override_headers["User-Agent"] = USER_AGENT
+      http.override_headers["Cookie"] = @cookie
+      yield(http)
+      http.shutdown
+    end
 
     def fetch_cookie
       http = Net::HTTP.get_response(URI(COOKIE_URL), { "Keep-Session-Cookies" => "true" })
@@ -96,7 +96,8 @@ module BasicYahooFinance
 
     def process_history_output(json)
       # Handle error from the API that the code isn't found
-      return json["error"] unless json["error"].nil?
+      error = json.dig("chart", "error")
+      return error unless error.nil?
 
       json
     end

--- a/lib/basic_yahoo_finance/version.rb
+++ b/lib/basic_yahoo_finance/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module BasicYahooFinance
-  VERSION = "0.6.0"
+  VERSION = "0.5.1"
 end

--- a/lib/basic_yahoo_finance/version.rb
+++ b/lib/basic_yahoo_finance/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module BasicYahooFinance
-  VERSION = "0.5.1"
+  VERSION = "0.6.0"
 end

--- a/test/test_basic_yahoo_finance.rb
+++ b/test/test_basic_yahoo_finance.rb
@@ -51,7 +51,9 @@ class BasicYahooFinanceTest < Minitest::Test
 
   def test_history_invalid_ticker
     result = @query.history("ZZZZ", 1_700_000_000, 1_710_000_000)
-    assert_includes(result["ZZZZ"]["chart"], "error")
+    error = result["ZZZZ"]
+    assert_equal "Not Found", error["code"]
+    assert_includes error["description"], "No data found"
   end
 
   def test_history_valid_tickers


### PR DESCRIPTION
## Summary

- Add history method to retrieve historical price data via the /v8/finance/chart endpoint
- Supports single/multiple symbols and configurable intervals (1d, 1wk, etc.)
- Properly extracts API errors from the chart.error response path

## Changes

- lib/basic_yahoo_finance.rb: Added history and process_history_output methods
- test/test_basic_yahoo_finance.rb: 5 new tests (valid/invalid ticker, multiple tickers, custom interval, HTTP error)
- README.md: Documented the new method with usage examples
- CHANGELOG.md: Added entry under Unreleased
- version.rb: Bumped to 0.6.0

## Test plan

- All 15 tests pass with 100% line coverage
- rake test passes cleanly